### PR TITLE
Fix wrong import in matrix demo

### DIFF
--- a/lab1_amm/main_matrix.py
+++ b/lab1_amm/main_matrix.py
@@ -1,6 +1,6 @@
 # lab1_amm/main_matrix.py
 
-from matrix import Matrix
+from lab1_amm.matrix import Matrix
 
 
 def main():


### PR DESCRIPTION
## Summary
- fix module import path in `main_matrix.py`

## Testing
- `python lab1_amm/main_matrix.py` *(fails: ModuleNotFoundError)*
- `python -m lab1_amm.main_matrix`
- `python main.py`
- `python -m py_compile main.py lab1_amm/matrix.py lab2_floyd/floyd_warshall.py lab3_path/path_reconstruction.py lab4_parallel/cannon.py lab1_amm/main_matrix.py`


------
https://chatgpt.com/codex/tasks/task_e_683f59e647048322a2b19ee778250f3f